### PR TITLE
ACL 관리 권한에 perm:aclgroup 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+css/*.css
+js/*.js
+- js/banana.js
+node_modules/
+*.db

--- a/server.js
+++ b/server.js
@@ -1877,6 +1877,7 @@ const aclperms = {
 	member: '로그인된 사용자',
 	admin: '관리자',
 	member_signup_15days_ago: '가입한지 15일 지난 사용자',
+	aclgroup: (ver('4.18.0') ? 'ACL 관리자' : undefined),
 	suspend_account: (ver('4.18.0') ? undefined : '차단된 사용자'),
 	blocked_ipacl: (ver('4.18.0') >= 18 ? undefined : '차단된 아이피'),
 	document_contributor: '해당 문서 기여자',


### PR DESCRIPTION
확인해보니까 perm:aclgroup이 표시가 안 되더라고요? (표시 안 되면 추가도 불가)
그래서 살짝 건드려서 표시되게 해줬습니다.

예제: Liberty 스킨 표시 예제 (테스트 서버: http://wiki.jdh5968.pe.kr:8800/acl/FrontPage)
[![Display_Example](https://user-images.githubusercontent.com/34373595/197463842-b52f9168-3bb4-44a6-81c0-8c8140bd0799.png)](http://wiki.jdh5968.pe.kr:8800/acl/FrontPage)
